### PR TITLE
Add backend-issued tag credentials to prevent spoofing

### DIFF
--- a/lib/leaderboard-client.js
+++ b/lib/leaderboard-client.js
@@ -126,7 +126,14 @@ function normalizeConfig(raw) {
       ? Math.trunc(cfg.reportIntervalMs)
       : DEFAULT_REPORT_INTERVAL_MS;
 
-  return { gamerTag: tag, telemetryEnabled, apiBaseUrl, reportIntervalMs };
+  const out = { gamerTag: tag, telemetryEnabled, apiBaseUrl, reportIntervalMs };
+  // Server-issued credential proving this install first claimed `gamerTag`.
+  // Only carried when present; absent means "not yet registered" (a fresh tag,
+  // or a legacy install predating credentials). saveConfig's JSON.stringify
+  // drops undefined keys, so an absent secret never lands on disk.
+  const tagSecret = typeof cfg.tagSecret === 'string' && cfg.tagSecret ? cfg.tagSecret : undefined;
+  if (tagSecret) out.tagSecret = tagSecret;
+  return out;
 }
 
 /** Read + normalize config from disk. Never throws; returns defaults on error. */
@@ -222,7 +229,9 @@ class LeaderboardClient {
 
   /** Make a new anonymous tag (user-facing "reroll"). Returns the new tag. */
   regenerateTag() {
-    this.config = { ...this.config, gamerTag: generateTag() };
+    // A new tag has no valid credential — drop the old secret so the next report
+    // re-registers under the new tag (undefined is dropped from disk on save).
+    this.config = { ...this.config, gamerTag: generateTag(), tagSecret: undefined };
     this._persist();
     return this.config.gamerTag;
   }
@@ -230,7 +239,8 @@ class LeaderboardClient {
   /** Set a custom tag the user typed. Returns the sanitized value used. */
   setTag(tag) {
     const clean = sanitizeTag(tag) || generateTag();
-    this.config = { ...this.config, gamerTag: clean };
+    // Changing tags invalidates the stored secret; clear it so we re-register.
+    this.config = { ...this.config, gamerTag: clean, tagSecret: undefined };
     this._persist();
     return this.config.gamerTag;
   }
@@ -249,6 +259,58 @@ class LeaderboardClient {
   }
 
   /**
+   * Ensure this install holds a credential for its current tag. Invisible to the
+   * user: on first report we POST { tag } to /api/register, store the returned
+   * secret in config.json, and reuse it forever. If the tag was already claimed
+   * by someone else (409), we reroll to a fresh tag and retry once so the user
+   * still lands on the board. Never throws; on any error we stay unregistered
+   * and the next report tick retries. Runs inside reportNow's _reporting guard,
+   * so it never overlaps a report or another registration.
+   */
+  async _ensureRegistered() {
+    if (!this.config.telemetryEnabled) return;
+    if (!this.fetchImpl) return;
+    if (this.config.tagSecret) return; // already registered
+
+    const registerUrl = this.config.apiBaseUrl.replace(/\/+$/, '') + '/api/register';
+
+    const attempt = async (tag) => {
+      const controller = typeof AbortController === 'function' ? new AbortController() : null;
+      const timeout = controller ? setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS) : null;
+      try {
+        const res = await this.fetchImpl(registerUrl, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ tag }),
+          signal: controller ? controller.signal : undefined,
+        });
+        if (res && res.status === 409) return 'taken';
+        if (res && res.ok) {
+          const data = await res.json();
+          if (data && data.ok && typeof data.secret === 'string' && data.secret) {
+            this.config = { ...this.config, tagSecret: data.secret };
+            this._persist();
+            return 'ok';
+          }
+        }
+        return 'fail';
+      } catch {
+        return 'fail'; // network error / abort — stay unregistered, retry next tick
+      } finally {
+        if (timeout) clearTimeout(timeout);
+      }
+    };
+
+    const first = await attempt(this.config.gamerTag);
+    if (first === 'taken') {
+      // Someone else owns this (publicly visible) tag — reroll and try once more.
+      this.config = { ...this.config, gamerTag: generateTag(), tagSecret: undefined };
+      this._persist();
+      await attempt(this.config.gamerTag);
+    }
+  }
+
+  /**
    * Send one report. Resolves to true if the server accepted it, false in every
    * other case (disabled, no fetch, network error, bad status). Never throws,
    * never retries — the next scheduled tick is the only "retry".
@@ -263,15 +325,22 @@ class LeaderboardClient {
     const timeout = controller ? setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS) : null;
 
     try {
+      // Register transparently before the first report (no-op once we hold a
+      // secret). Guarded by _reporting, so it never races another report.
+      await this._ensureRegistered();
+
       let total = this.getTotal();
       if (typeof total !== 'number' || !isFinite(total) || total < 0) total = 0;
       total = Math.round(total * 100) / 100;
+
+      const body = { tag: this.config.gamerTag, total };
+      if (this.config.tagSecret) body.secret = this.config.tagSecret;
 
       const url = this.config.apiBaseUrl.replace(/\/+$/, '') + '/api/report';
       const res = await this.fetchImpl(url, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ tag: this.config.gamerTag, total }),
+        body: JSON.stringify(body),
         signal: controller ? controller.signal : undefined,
       });
       return !!(res && res.ok);

--- a/server/db.js
+++ b/server/db.js
@@ -2,7 +2,13 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('node:crypto');
 const { DatabaseSync } = require('node:sqlite');
+
+/** SHA-256 of a string, hex-encoded. */
+function sha256hex(s) {
+  return crypto.createHash('sha256').update(String(s), 'utf8').digest('hex');
+}
 
 /**
  * Tiny zero-dependency SQLite store for the daily leaderboard, backed by the
@@ -31,6 +37,20 @@ class LeaderboardDB {
         ');'
     );
 
+    // Anti-spoofing: a tag can only be reported by whoever first claimed it.
+    // On first sight of a tag we mint a random secret, store only its SHA-256
+    // hash here, and hand the raw secret back to that client once. Later reports
+    // must present the matching secret. This table is deliberately NOT pruned
+    // (unlike `leaderboard`): a credential must outlive daily resets and server
+    // redeploys, so it lives forever in the persistent DB.
+    this.db.exec(
+      'CREATE TABLE IF NOT EXISTS tag_credentials (' +
+        'tag TEXT PRIMARY KEY, ' +
+        'secret_hash TEXT NOT NULL, ' +
+        'created_day TEXT NOT NULL' +
+        ');'
+    );
+
     // Prepared statements only — no string interpolation into SQL.
     this._reportStmt = this.db.prepare(
       'INSERT INTO leaderboard (day, tag, total) VALUES (?, ?, ?) ' +
@@ -40,7 +60,16 @@ class LeaderboardDB {
     this._boardStmt = this.db.prepare(
       'SELECT tag, total FROM leaderboard WHERE day = ? ORDER BY total DESC LIMIT ?;'
     );
+    // NOTE: prune targets `leaderboard` ONLY. Credentials are never pruned.
     this._pruneStmt = this.db.prepare('DELETE FROM leaderboard WHERE day NOT IN (?, ?);');
+
+    // Credential statements. INSERT is a no-op if the tag was already claimed,
+    // so the read-back tells us whether we actually won the claim.
+    this._claimStmt = this.db.prepare(
+      'INSERT INTO tag_credentials (tag, secret_hash, created_day) VALUES (?, ?, ?) ' +
+        'ON CONFLICT(tag) DO NOTHING;'
+    );
+    this._credStmt = this.db.prepare('SELECT secret_hash FROM tag_credentials WHERE tag = ?;');
   }
 
   /** UTC calendar day, e.g. "2026-07-09". */
@@ -59,6 +88,40 @@ class LeaderboardDB {
   /** Today's leaderboard, sorted high-to-low, capped at `limit`. */
   leaderboard(day = LeaderboardDB.today(), limit = 100) {
     return this._boardStmt.all(day, limit).map((r) => ({ tag: r.tag, total: r.total }));
+  }
+
+  /**
+   * Claim a tag: mint a fresh secret and store its hash the first time a tag is
+   * seen. Returns the RAW secret (shown once, never persisted) on success, or
+   * `null` if the tag was already claimed by someone else.
+   *
+   * Race-safe: `INSERT ... ON CONFLICT DO NOTHING` is atomic, and we then read
+   * the stored hash back. If it isn't the hash we just tried to write, another
+   * writer won the claim first, so we return null.
+   */
+  claimTag(tag, day = LeaderboardDB.today()) {
+    const secret = crypto.randomBytes(24).toString('base64url');
+    const hash = sha256hex(secret);
+    this._claimStmt.run(tag, hash, day);
+    const row = this._credStmt.get(tag);
+    if (!row || row.secret_hash !== hash) return null; // someone else claimed it
+    return secret;
+  }
+
+  /**
+   * Verify a presented secret against a tag's stored credential.
+   * Returns 'unregistered' when the tag has no credential row, 'valid' when the
+   * secret's SHA-256 matches, and 'invalid' otherwise (including missing/empty
+   * or non-string secrets). Uses a constant-time compare on the hex digests.
+   */
+  verifyCredential(tag, secret) {
+    const row = this._credStmt.get(tag);
+    if (!row) return 'unregistered';
+    if (typeof secret !== 'string' || secret.length === 0) return 'invalid';
+    const presented = Buffer.from(sha256hex(secret), 'hex');
+    const stored = Buffer.from(row.secret_hash, 'hex');
+    if (presented.length !== stored.length) return 'invalid';
+    return crypto.timingSafeEqual(presented, stored) ? 'valid' : 'invalid';
   }
 
   /** Drop days other than today + yesterday so the DB can't grow forever. */

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,10 @@
  * Deploys to Railway with:  railway up ./server
  *
  * Endpoints:
- *   POST /api/report        body { tag: string, total: number } -> { ok, total }
+ *   POST /api/register      body { tag: string } -> { ok, tag, secret } (claims a
+ *                           tag once; returns a secret shown a single time)
+ *   POST /api/report        body { tag: string, total: number, secret?: string }
+ *                           -> { ok, total } (secret authenticates a claimed tag)
  *   GET  /api/leaderboard   -> { date, entries: [{ tag, total }] } (today only)
  *   GET  /api/stars         -> { stars: number|null } (GitHub stars, cached)
  *   GET  /                  -> static landing page (server/public/index.html)
@@ -36,6 +39,13 @@ const TAG_MAX_LENGTH = 32;
 // low hundreds of dollars; a $10,000/day default ceiling is generous while still
 // keeping the board honest. Tunable via MAX_REPORT_TOTAL for edge cases.
 const MAX_TOTAL = Number(process.env.MAX_REPORT_TOTAL) || 10000;
+
+// When true, reports for an UNREGISTERED tag are rejected (401) instead of being
+// accepted on trust. Default is SOFT (false): existing installs that predate the
+// credential feature keep reporting until they auto-register, so the board never
+// goes dark during the migration. Flip REQUIRE_SIGNED=1 once clients have rolled
+// forward to enforce that every report carries a valid secret.
+const REQUIRE_SIGNED = /^(1|true|yes)$/i.test(String(process.env.REQUIRE_SIGNED || ''));
 
 // ── Per-IP rate limiting for POST /api/report ───────────────────────────────
 // Legit clients report at most hourly, so a generous ceiling (60 req/min/IP by
@@ -199,6 +209,34 @@ function readBody(req) {
   });
 }
 
+// Claim a tag and return its one-time secret. Reuses handleReport's body/JSON
+// handling so oversized bodies still get a 413 and malformed JSON a 400.
+async function handleRegister(req, res) {
+  let raw;
+  try {
+    raw = await readBody(req);
+  } catch (err) {
+    if (err && err.code === 'BODY_TOO_LARGE') {
+      return sendJSON(res, 413, { ok: false, error: 'body_too_large' });
+    }
+    return sendJSON(res, 400, { ok: false, error: 'invalid_json' });
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return sendJSON(res, 400, { ok: false, error: 'invalid_json' });
+  }
+
+  const tag = sanitizeTag(payload && payload.tag);
+  if (!tag) return sendJSON(res, 400, { ok: false, error: 'invalid_tag' });
+
+  const secret = db.claimTag(tag);
+  if (secret === null) return sendJSON(res, 409, { ok: false, error: 'tag_taken' });
+  return sendJSON(res, 200, { ok: true, tag, secret });
+}
+
 async function handleReport(req, res) {
   let raw;
   try {
@@ -224,6 +262,17 @@ async function handleReport(req, res) {
     return sendJSON(res, 400, { ok: false, error: 'invalid_total' });
   }
   total = Math.round(total * 100) / 100;
+
+  // Anti-spoofing gate. A claimed tag must present its secret; an unknown tag is
+  // trusted only while REQUIRE_SIGNED is off (soft migration — see the env const).
+  const secret = payload && payload.secret;
+  const status = db.verifyCredential(tag, secret);
+  if (status === 'invalid') {
+    return sendJSON(res, 401, { ok: false, error: 'unauthorized' });
+  }
+  if (status === 'unregistered' && REQUIRE_SIGNED) {
+    return sendJSON(res, 401, { ok: false, error: 'registration_required' });
+  }
 
   const stored = db.report(tag, total);
   return sendJSON(res, 200, { ok: true, total: stored });
@@ -256,6 +305,13 @@ const server = http.createServer((req, res) => {
 
   if (req.method === 'OPTIONS') { return sendJSON(res, 204, {}); }
 
+  if (req.method === 'POST' && pathname === '/api/register') {
+    const limit = checkRateLimit(clientIp(req));
+    if (!limit.allowed) {
+      return sendJSON(res, 429, { ok: false, error: 'rate_limited' }, { 'retry-after': String(limit.retryAfterSec) });
+    }
+    return handleRegister(req, res);
+  }
   if (req.method === 'POST' && pathname === '/api/report') {
     const limit = checkRateLimit(clientIp(req));
     if (!limit.allowed) {

--- a/test/leaderboard-client.test.js
+++ b/test/leaderboard-client.test.js
@@ -279,6 +279,84 @@ const configFile = (dir) => path.join(dir, 'config.json');
 
   console.log('client reporting (payload minimalism, disable, fail-silent): OK');
 
+  // ── Auto-registration: first report claims a secret, then sends it ───────────
+  {
+    const dir = path.join(tmpRoot, 'autoreg');
+    const calls = [];
+    const fetchImpl = async (url, opts) => {
+      calls.push({ url, body: JSON.parse(opts.body) });
+      if (url.endsWith('/api/register')) {
+        return { ok: true, status: 200, json: async () => ({ ok: true, tag: JSON.parse(opts.body).tag, secret: 'SEKRET123' }) };
+      }
+      return { ok: true, status: 200 }; // /api/report
+    };
+    const c = new LeaderboardClient({ configDir: dir, getTotal: () => 3.21, fetchImpl });
+    const sent = await c.reportNow();
+    assert.strictEqual(sent, true, 'report succeeds after auto-register');
+    assert.strictEqual(calls.length, 2, 'exactly two calls: register then report');
+    assert.ok(calls[0].url.endsWith('/api/register'), 'first call is /api/register');
+    assert.deepStrictEqual(Object.keys(calls[0].body).sort(), ['tag'], 'register body is just { tag }');
+    assert.ok(calls[1].url.endsWith('/api/report'), 'second call is /api/report');
+    assert.strictEqual(calls[1].body.secret, 'SEKRET123', 'report carries the freshly issued secret');
+    assert.strictEqual(calls[1].body.total, 3.21, 'report carries the total');
+    // Secret persisted to disk.
+    assert.strictEqual(loadConfig(dir).tagSecret, 'SEKRET123', 'secret persisted to config.json');
+
+    // A second report reuses the stored secret WITHOUT re-registering.
+    calls.length = 0;
+    await c.reportNow();
+    assert.strictEqual(calls.length, 1, 'second report does not re-register');
+    assert.ok(calls[0].url.endsWith('/api/report'), 'second report hits /api/report directly');
+    assert.strictEqual(calls[0].body.secret, 'SEKRET123', 'reuses the stored secret');
+    console.log('client auto-register (register once, then sends secret with reports): OK');
+  }
+
+  // ── 409 on register: reroll the tag and retry once ───────────────────────────
+  {
+    const dir = path.join(tmpRoot, 'autoreg-taken');
+    const calls = [];
+    let firstRegister = true;
+    const fetchImpl = async (url, opts) => {
+      const body = JSON.parse(opts.body);
+      calls.push({ url, body });
+      if (url.endsWith('/api/register')) {
+        if (firstRegister) { firstRegister = false; return { ok: false, status: 409, json: async () => ({ ok: false, error: 'tag_taken' }) }; }
+        return { ok: true, status: 200, json: async () => ({ ok: true, tag: body.tag, secret: 'SECOND' }) };
+      }
+      return { ok: true, status: 200 };
+    };
+    const c = new LeaderboardClient({ configDir: dir, getTotal: () => 1, fetchImpl });
+    const firstTag = c.gamerTag;
+    await c.reportNow();
+    const registers = calls.filter((x) => x.url.endsWith('/api/register'));
+    assert.strictEqual(registers.length, 2, 'registered twice (initial 409 then retry)');
+    assert.notStrictEqual(c.gamerTag, firstTag, 'tag was rerolled after 409');
+    assert.strictEqual(loadConfig(dir).tagSecret, 'SECOND', 'secret from the retry persisted');
+    console.log('client auto-register 409 -> reroll + retry once: OK');
+  }
+
+  // ── Tag change clears the stored secret (forces re-registration) ─────────────
+  {
+    const dir = path.join(tmpRoot, 'secret-clear');
+    const client = new LeaderboardClient({ configDir: dir, getTotal: () => 0, fetchImpl: null });
+    // Seed a secret directly.
+    client.config = { ...client.config, tagSecret: 'OLD' };
+    client._persist();
+    assert.strictEqual(loadConfig(dir).tagSecret, 'OLD', 'seeded secret on disk');
+
+    client.regenerateTag();
+    assert.strictEqual(client.config.tagSecret, undefined, 'regenerateTag clears in-memory secret');
+    assert.strictEqual(loadConfig(dir).tagSecret, undefined, 'regenerateTag clears persisted secret');
+
+    // Re-seed then change via setTag.
+    client.config = { ...client.config, tagSecret: 'OLD2' };
+    client._persist();
+    client.setTag('BrandNewTag');
+    assert.strictEqual(client.config.tagSecret, undefined, 'setTag clears in-memory secret');
+    assert.strictEqual(loadConfig(dir).tagSecret, undefined, 'setTag clears persisted secret');
+    console.log('client tag change clears tagSecret (regenerateTag + setTag): OK');
+  }
+
   fs.rmSync(tmpRoot, { recursive: true, force: true });
   console.log('\nAll leaderboard-client tests passed.');
 })().catch((err) => {

--- a/test/leaderboard-db.test.js
+++ b/test/leaderboard-db.test.js
@@ -94,6 +94,30 @@ const OLD_DAY = LeaderboardDB.today(new Date(Date.parse(TODAY + 'T00:00:00Z') - 
   console.log('old-day pruning: OK');
 }
 
+// ── Tag credentials: claim once, verify, reject spoof, survive pruning ────────
+{
+  const db = new LeaderboardDB(dbPath);
+
+  // First claim mints a raw secret; the tag now has a credential.
+  const secret = db.claimTag('OwnerTag');
+  assert.ok(typeof secret === 'string' && secret.length > 0, 'claimTag returns a non-empty secret');
+  assert.strictEqual(db.claimTag('OwnerTag'), null, 're-claiming the same tag returns null');
+
+  // Verify trichotomy: valid / invalid / unregistered.
+  assert.strictEqual(db.verifyCredential('OwnerTag', secret), 'valid', 'correct secret is valid');
+  assert.strictEqual(db.verifyCredential('OwnerTag', 'wrong'), 'invalid', 'wrong secret is invalid');
+  assert.strictEqual(db.verifyCredential('OwnerTag', ''), 'invalid', 'empty secret is invalid');
+  assert.strictEqual(db.verifyCredential('OwnerTag', null), 'invalid', 'non-string secret is invalid');
+  assert.strictEqual(db.verifyCredential('NeverSeen', 'x'), 'unregistered', 'unknown tag is unregistered');
+
+  // Credentials must survive the daily prune (which only touches `leaderboard`).
+  db.report('AncientTag', 1, OLD_DAY);
+  db.report('FreshTag', 1, TODAY); // triggers _pruneOldDays
+  assert.strictEqual(db.verifyCredential('OwnerTag', secret), 'valid', 'credential survives pruning');
+  db.close();
+  console.log('tag credentials (claim once, verify trichotomy, prune-immune): OK');
+}
+
 // force + retries: on Windows the WAL sidecar files can linger a beat after close.
 fs.rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 delete process.env.LEADERBOARD_DB;

--- a/test/leaderboard-server.test.js
+++ b/test/leaderboard-server.test.js
@@ -216,6 +216,63 @@ function rawPost(urlPath, rawBody) {
     console.log('server: security headers (nosniff + JSON type + CSP on HTML): OK');
   }
 
+  // ── Tag credentials: register + secret-authenticated reports ────────────────
+  // Each block uses a DISTINCT x-forwarded-for IP so register+report pairs never
+  // exhaust the shared 127.0.0.1 rate-limit window used by the cases above.
+  {
+    const ip = { 'x-forwarded-for': '198.51.100.20' };
+
+    // Fresh tag registers and gets a non-empty secret.
+    const reg = await request('POST', '/api/register', { tag: 'CredHolder' }, ip);
+    assert.strictEqual(reg.status, 200, 'register fresh tag -> 200');
+    const regBody = JSON.parse(reg.body);
+    assert.strictEqual(regBody.ok, true, 'register ok:true');
+    assert.strictEqual(regBody.tag, 'CredHolder', 'register echoes the tag');
+    assert.ok(typeof regBody.secret === 'string' && regBody.secret.length > 0, 'register returns a non-empty secret');
+    const secret = regBody.secret;
+
+    // Re-registering the SAME tag is rejected as taken.
+    const dup = await request('POST', '/api/register', { tag: 'CredHolder' }, ip);
+    assert.strictEqual(dup.status, 409, 're-register same tag -> 409');
+    assert.strictEqual(JSON.parse(dup.body).error, 'tag_taken', '409 error is tag_taken');
+    console.log('server: register fresh tag (200 + secret), duplicate (409 tag_taken): OK');
+
+    // Correct secret -> report accepted and it appears on the board.
+    const good = await request('POST', '/api/report', { tag: 'CredHolder', total: 42, secret }, ip);
+    assert.strictEqual(good.status, 200, 'report with correct secret -> 200');
+    assert.strictEqual(JSON.parse(good.body).total, 42, 'correct-secret report stores the total');
+    let board = JSON.parse((await request('GET', '/api/leaderboard')).body);
+    assert.ok(board.entries.some((e) => e.tag === 'CredHolder' && e.total === 42), 'registered tag on the board at 42');
+    console.log('server: report with valid secret recorded: OK');
+
+    // Wrong secret -> 401, and the stored total is unchanged (not recorded).
+    const bad = await request('POST', '/api/report', { tag: 'CredHolder', total: 500, secret: 'not-the-secret' }, ip);
+    assert.strictEqual(bad.status, 401, 'report with wrong secret -> 401');
+    assert.strictEqual(JSON.parse(bad.body).error, 'unauthorized', '401 error is unauthorized');
+    board = JSON.parse((await request('GET', '/api/leaderboard')).body);
+    const afterWrong = board.entries.find((e) => e.tag === 'CredHolder');
+    assert.strictEqual(afterWrong.total, 42, 'wrong-secret report did NOT change the total');
+
+    // No secret for a registered tag -> 401, not recorded.
+    const none = await request('POST', '/api/report', { tag: 'CredHolder', total: 900 }, ip);
+    assert.strictEqual(none.status, 401, 'report with NO secret for a registered tag -> 401');
+    assert.strictEqual(JSON.parse(none.body).error, 'unauthorized', 'missing-secret error is unauthorized');
+    board = JSON.parse((await request('GET', '/api/leaderboard')).body);
+    assert.strictEqual(board.entries.find((e) => e.tag === 'CredHolder').total, 42, 'missing-secret report not recorded');
+    console.log('server: registered tag rejects wrong/absent secret (401, unchanged): OK');
+  }
+
+  // ── Soft migration: an UNREGISTERED tag with no secret is still accepted ─────
+  {
+    const ip = { 'x-forwarded-for': '198.51.100.21' };
+    const res = await request('POST', '/api/report', { tag: 'LegacyTrust', total: 7 }, ip);
+    assert.strictEqual(res.status, 200, 'unregistered tag, no secret -> 200 (soft default)');
+    assert.strictEqual(JSON.parse(res.body).total, 7, 'legacy report stores the total');
+    const board = JSON.parse((await request('GET', '/api/leaderboard')).body);
+    assert.ok(board.entries.some((e) => e.tag === 'LegacyTrust' && e.total === 7), 'legacy tag on the board');
+    console.log('server: unregistered tag accepted on trust (REQUIRE_SIGNED off): OK');
+  }
+
   await new Promise((r) => server.close(r));
   db.close(); // release the SQLite handle so Windows can delete the temp file
   fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });


### PR DESCRIPTION
## What & why

Adds backend-issued **per-tag credentials** so a leaderboard tag can only be reported by whoever first claimed it. This closes the tag-spoofing/griefing gap (reporting under someone else's public tag) with the simplest scheme that needs no login or account, and **zero new UX** — registration is invisible.

Self-inflation of your *own* total remains intentionally out of scope (unsolvable for a self-reported metric; this is a vanity board).

## How it works

- **`server/db.js`** — new `tag_credentials(tag PK, secret_hash, created_day)` table, deliberately **excluded from the daily prune** so credentials survive resets and redeploys. `claimTag()` mints a random secret (`crypto.randomBytes(24).base64url`), stores only its **SHA-256 hash**, and is race-safe (`INSERT … ON CONFLICT DO NOTHING` + read-back). `verifyCredential()` returns `unregistered` / `valid` / `invalid` using a constant-time compare.
- **`server/index.js`** — `POST /api/register` (rate-limited like report) claims a tag once and returns the secret a single time (`409 tag_taken` if already claimed). `POST /api/report` now verifies the secret: a **registered** tag with a wrong/absent secret is rejected `401` and **not recorded**; an **unregistered** tag is accepted on trust **unless** `REQUIRE_SIGNED=1`.
- **`lib/leaderboard-client.js`** — transparent auto-register on first report; the secret is stored in `config.json` and sent with every report. Changing the tag (reroll or custom) clears the secret so the new tag re-registers. All best-effort/silent as before. **No tray/menu changes.**

## Migration (minimal friction)

`REQUIRE_SIGNED` defaults **off** (soft). Existing installs keep reporting and auto-register on their next report, so the board never goes dark. Flip `REQUIRE_SIGNED=1` on the server once clients have rolled forward to enforce signatures for everyone. Users keep their tags across client upgrades (`config.json`) and server redeploys (credentials on the persistent volume).

## Accepted risks

- **Land-grab:** because tags are public on the board, someone could register a rival's *still-unregistered* tag first. Intrinsic to any first-come-claim scheme; the rate limiter only slows bulk attempts. Acceptable for a vanity board; `REQUIRE_SIGNED` is the lever to tighten later.
- **Self-inflation:** unchanged, out of scope by design.

## Tests

Full suite green (`npm test`, exit 0). Added coverage: register (200 + secret) / duplicate `409`; report with valid secret recorded; registered tag rejects wrong/absent secret (`401`, total unchanged); unregistered tag soft-accepted; DB-level claim-once / verify-trichotomy / prune-immunity; client auto-register-then-report, `409`→reroll+retry, and secret cleared on tag change.

Zero runtime dependencies preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
