### PR TITLE
fix(publish): drop in-place npm upgrade that broke --provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,10 +37,12 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      # Trusted Publishing (OIDC) requires a recent npm. It landed in npm
-      # 11.5.1, and the npm bundled with Node may be older, so upgrade to latest.
-      - name: Upgrade npm (Trusted Publishing needs npm >= 11.5.1)
-        run: npm install -g npm@latest
+      # Trusted Publishing (OIDC) needs npm >= 11.5.1; Node 24 already bundles a
+      # newer npm (11.16.0), so we use it as-is. Do NOT `npm install -g npm@latest`
+      # here: the in-place self-upgrade corrupts npm's own dependency tree and
+      # drops `sigstore`, which breaks `npm publish --provenance`.
+      - name: Show npm version
+        run: npm --version
 
       # Guard against publishing a version that doesn't match the release tag.
       # The release tag (github.ref_name) may be prefixed with "v" (e.g.


### PR DESCRIPTION
## Problem

The `v1.0.2` publish [failed](https://github.com/gceico/claude-make-it-rain/actions/runs/29046908789) with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
```

…during `npm publish --provenance`. `1.0.2` never made it to npm.

## Cause

The workflow ran `npm install -g npm@latest`, which self-upgrades npm **in place** and leaves its own dependency tree incomplete — the step logged `removed 16 packages, and changed 65 packages`, dropping `sigstore`, which the provenance code path requires.

That step was also **unnecessary**: the job runs on Node 24, which bundles **npm 11.16.0** — already above the 11.5.1 that Trusted Publishing needs.

## Fix

Remove the in-place upgrade and use the bundled npm as-is (with a `npm --version` line for visibility). No other changes.

## After merge — how to publish

`1.0.2` was never published, and `package.json` on `main` is still at `1.0.2`, so re-point the tag at the fixed commit:

```bash
git checkout main && git pull
git tag -d v1.0.2 && git push origin :v1.0.2   # remove the old tag (it built the broken workflow)
git tag v1.0.2 && git push origin v1.0.2        # re-tag HEAD -> re-runs publish with the fix
```

Or skip 1.0.2 entirely and cut a fresh version: `npm version patch && git push --follow-tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)