### PR TITLE
fix: repair broken update-checker test and dead raw assignments

### DIFF
--- a/lib/leaderboard-client.js
+++ b/lib/leaderboard-client.js
@@ -132,7 +132,7 @@ function normalizeConfig(raw) {
 /** Read + normalize config from disk. Never throws; returns defaults on error. */
 function loadConfig(configDir) {
   const file = path.join(configDir, CONFIG_FILENAME);
-  let raw = null;
+  let raw;
   try {
     raw = JSON.parse(fs.readFileSync(file, 'utf8'));
   } catch {
@@ -174,7 +174,7 @@ function saveConfig(configDir, config) {
  */
 function ensureConfig(configDir) {
   const file = path.join(configDir, CONFIG_FILENAME);
-  let raw = null;
+  let raw;
   try {
     raw = JSON.parse(fs.readFileSync(file, 'utf8'));
   } catch {

--- a/test/update-checker.test.js
+++ b/test/update-checker.test.js
@@ -170,9 +170,14 @@ const {
     assert.strictEqual(await c.checkNow(), null, 'no version field -> null');
   }
 
-  // No fetch available at all: null, never throws.
+  // No fetch available at all: null, never throws. The constructor falls back
+  // to global fetch when none is injected, so to exercise the guard for an
+  // environment without fetch we null it on the instance (rather than passing
+  // fetchImpl: null, which the fallback would replace with global fetch and
+  // send a real network request).
   {
-    const c = new UpdateChecker({ currentVersion: CURRENT, fetchImpl: null });
+    const c = new UpdateChecker({ currentVersion: CURRENT });
+    c.fetchImpl = null;
     assert.strictEqual(await c.checkNow(), null, 'no fetchImpl -> null');
   }
 


### PR DESCRIPTION
Two pre-existing issues on `main` that were blocking other PRs' CI:

1. **`test/update-checker.test.js`** — the "no fetchImpl" case passed `fetchImpl: null`, but the `UpdateChecker` constructor falls back to global `fetch` when none is injected. The test therefore hit the live npm registry (returning `{version:'1.0.2'}`) instead of exercising the guard, failing deterministically in CI. Now nulls the instance field directly so the test is offline and deterministic.

2. **`lib/leaderboard-client.js`** — dropped two dead `let raw = null` initializers (both `try`/`catch` branches reassign before use). eslint 9 tolerates them; eslint 10 (incoming via #10) flags `no-useless-assignment`.

Unblocks #14 (test) and #10 (lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)