### PR TITLE
fix: stop stray macOS microphone permission prompt

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { app, BrowserWindow, Tray, Menu, Notification, ipcMain, nativeImage, screen, shell } = require('electron');
+const { app, BrowserWindow, Tray, Menu, Notification, ipcMain, nativeImage, screen, shell, session } = require('electron');
 const path = require('path');
 const { execFile } = require('child_process');
 const { UsageMonitor } = require('./lib/usage-monitor');
@@ -10,6 +10,17 @@ const { LeaderboardClient } = require('./lib/leaderboard-client');
 const { History, RANGES, billCount } = require('./lib/history');
 const { stackCountForCrossing } = require('./lib/milestones');
 const { UpdateChecker, shouldNotify } = require('./lib/update-checker');
+
+// We only ever play synthesized output audio (Web Audio oscillators in the
+// overlay) — nothing here captures audio. On macOS, Chromium's audio stack can
+// still initialize a CoreAudio *input* unit when an AudioContext starts, which
+// trips the OS microphone-permission prompt (attributed to the launching
+// terminal, since the CLI isn't a signed .app bundle). As a belt-and-suspenders
+// against any capture path ever opening the real device, route media streams to
+// a fake device. The authoritative fix is the permission handlers registered in
+// whenReady() below. Switches must be set before app is ready, so this lives at
+// module top level.
+app.commandLine.appendSwitch('use-fake-device-for-media-stream');
 
 // ── Globals ─────────────────────────────────────────────────────────────────
 let tray = null;
@@ -471,6 +482,14 @@ if (!app.requestSingleInstanceLock()) {
 } else {
   app.whenReady().then(() => {
     if (process.platform === 'darwin' && app.dock) app.dock.hide();
+
+    // This app never needs the microphone, camera, or any other gated device.
+    // Deny every permission request/check so Chromium never escalates to the OS
+    // (and the user never sees a stray mic prompt from the launching terminal).
+    const ses = session.defaultSession;
+    ses.setPermissionRequestHandler((_wc, _permission, callback) => callback(false));
+    ses.setPermissionCheckHandler(() => false);
+    if (ses.setDevicePermissionHandler) ses.setDevicePermissionHandler(() => false);
 
     config = new Config(path.join(app.getPath('userData'), 'config.json'));
 


### PR DESCRIPTION
## Problem

A user reported the app triggering a **microphone access prompt** ("Allow Terminal.app to access your microphone") on macOS after `npm install -g @gceico/claude-make-it-rain`.

The app never captures audio — it only synthesizes the coin/shimmer sound with Web Audio oscillators in the overlay (`overlay.html`). The prompt is a Chromium/Electron quirk: when an `AudioContext` starts, Chromium's macOS audio stack can initialize a CoreAudio *input* unit, which trips the OS microphone-consent prompt. Because the CLI is launched via `spawn` from the shell and isn't a signed `.app` bundle, macOS attributes the request to the responsible parent process — the terminal — which looks alarming.

## Fix

In `main.js`:

- **Deny all permission requests/checks and device permissions** on the default session inside `whenReady()`. The app needs no gated devices, so Chromium never escalates to the OS. This is the authoritative fix.
- **Route media streams to a fake device** via `use-fake-device-for-media-stream` (set before app ready) as a belt-and-suspenders so no real hardware is ever opened, even if some capture path fires.

## Verification

- App launches cleanly in an isolated userData dir; permission handlers register without error.
- Full app test suite passes (`npm run test:app`).

Note: macOS caches the mic-consent decision per responsible app, so re-confirming visually requires a machine that never saw the prompt, or `tccutil reset Microphone` then relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)