### PR TITLE
chore: drop end-of-life Node 18/20, require Node 22+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,9 @@ on:
 # Comments track the human-readable version; bump the SHA + comment together
 # (Dependabot does this automatically).
 jobs:
-  # Full suite (app + leaderboard server). The server uses node:sqlite, which is
-  # a Node 22.5+ builtin, so the full suite only runs on 22+.
+  # Full suite (app + leaderboard server) across all supported platforms and
+  # Node versions. The app and server both require Node 22+ (the server uses the
+  # node:sqlite builtin, added in 22.5), matching package.json engines.
   test:
     name: test (node ${{ matrix.node }} / ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -33,26 +34,6 @@ jobs:
       - run: npm ci
       - run: npm test
 
-  # The published app supports Node 18+ (it never touches node:sqlite), so prove
-  # the app test suite still runs on the older baseline the README advertises.
-  test-app-legacy:
-    name: test:app (node ${{ matrix.node }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [18, 20]
-    env:
-      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: ${{ matrix.node }}
-          cache: npm
-      - run: npm ci
-      - run: npm run test:app
-
   lint:
     name: lint
     runs-on: ubuntu-latest
@@ -62,7 +43,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Clarified Node.js support: the desktop app requires Node 18+, while the
-  leaderboard server requires Node 22+ (it uses the `node:sqlite` builtin). CI
-  runs the full suite on 22/24 and the app-only suite on 18/20.
+- Raised the minimum Node.js version to 22 for both the desktop app and the
+  leaderboard server, dropping end-of-life Node 18 and 20. CI now runs the full
+  suite on Node 22/24 across Linux, macOS, and Windows.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ which spawns Electron detached).
 | Run (foreground, logs) | `npm start` (alias `npm run dev`) |
 | Run detached (like installed CLI) | `node bin/make-it-rain.js` |
 | Test everything | `npm test` (runs `test:app` then `test:server`) |
-| Test app only | `npm run test:app` (pure Node, Node 18+) |
+| Test app only | `npm run test:app` (pure Node, Node 22+) |
 | Test server only | `npm run test:server` (needs `node:sqlite`, Node 22+) |
 | Lint | `npm run lint` (`eslint .`) |
 | Format | `npm run format` / check with `npm run format:check` |
@@ -68,8 +68,8 @@ real devDependencies and installed; `npm run lint` works.
 
 ## Gotchas
 
-- `node:sqlite` landed in Node 22, so the server and `test:server` need Node ≥ 22,
-  even though the desktop app supports Node 18+.
+- `node:sqlite` landed in Node 22, so the server and `test:server` need Node ≥ 22;
+  the desktop app shares the same Node ≥ 22 baseline.
 - CI sets `ELECTRON_SKIP_BINARY_DOWNLOAD=1` for `npm ci` (tests never open a
   window, so the ~100 MB Electron binary is skipped).
 - Railway deploys the reference server from `server/` (`railway up ./server`),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ the process is light.
 
 ## Getting started
 
-The published app supports Node 18+, but development targets the current LTS
+The app and server both require Node 22+; development targets the current LTS
 (pinned in `.nvmrc`, matching the server's deploy image):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The dollar figure is a rough estimate from per-token pricing.
 
 ## Requirements
 
-- Node.js 18+ (you have this if you run Claude Code)
+- Node.js 22+ (you have this if you run Claude Code)
 - macOS, Windows, or Linux
 - Claude Code writing session logs to `~/.claude/projects` (the default)
 
@@ -179,9 +179,8 @@ node server/index.js          # listens on http://localhost:8787
 
 State lives in a small SQLite database (`server/data/leaderboard.db`, git-ignored),
 backed by the built-in `node:sqlite` module — still zero npm dependencies. The
-server therefore needs **Node >= 22** (where `node:sqlite` landed), even though
-the desktop app itself runs on Node 18+. Set `LEADERBOARD_DB` to override the
-file path.
+server uses `node:sqlite` (added in Node 22.5), and the desktop app shares the
+same **Node >= 22** baseline. Set `LEADERBOARD_DB` to override the file path.
 
 The reference server deploys to [Railway](https://railway.com) with `railway up ./server`,
 built from `server/Dockerfile` (`node:24-alpine`, no npm install, sleeps when idle;
@@ -221,7 +220,7 @@ MIR_TEST_SHOT=/tmp/overlay.png npm start  # save a PNG of the overlay 4s after l
   incremental/partial-line reads, crossing math.
 - `test/leaderboard-client.test.js` — tag generation/sanitization, config
   first-run/stability/recovery, telemetry toggle, and fail-silent reporting.
-- `.github/workflows/` — CI (tests on Linux/macOS/Windows × Node 18/20/22)
+- `.github/workflows/` — CI (tests on Linux/macOS/Windows × Node 22/24)
   and the npm publish pipeline.
 - `docs/DECISIONS.md` — architecture & decision log for the leaderboard,
   deployment, publishing, and security/anti-cheat work.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -96,9 +96,9 @@ durable, queryable state. Daily reset + prune keeps it a fun *of-the-day* board
 and bounds storage.
 
 **Tradeoffs / accepted risks.** `node:sqlite` is only available on **Node ≥ 22**
-(it did not exist in Node 18/20). The server therefore requires Node ≥ 22 even
-though the desktop app runs on Node 18+. Yesterday's data is discarded — this is
-intentional, not an archive.
+(it did not exist in Node 18/20). The server therefore requires Node ≥ 22, and
+the desktop app now shares that baseline (Node 18 and 20 are both end-of-life).
+Yesterday's data is discarded — this is intentional, not an archive.
 
 **Status.** Shipped.
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "win32"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "keywords": [
     "electron",


### PR DESCRIPTION
## What

Raises the project's minimum Node.js version to **22** for both the desktop app and the leaderboard server, dropping end-of-life Node 18 and 20.

## Why

From an audit of deprecated versions:
- **Node 18** — EOL 2025-04-30
- **Node 20** — EOL 2026-04-30 (both past end of life)
- The leaderboard server already required **Node 22** (`node:sqlite`).
- **eslint 10** (current devDependency) dropped Node 18 support entirely (requires `^20.19 || ^22.13 || >=24`), so `engines: ">=18"` was already inconsistent.

Everything else in the audit was already current: all npm deps at latest, 0 vulnerabilities, no deprecated packages, Actions SHA-pinned to `checkout@v7` / `setup-node@v6` (node24 runtime), flat ESLint config.

## Changes

- `package.json` engines: `>=18.0.0` → `>=22.0.0`
- CI: removed the Node 18/20 app-only job (the full suite already runs on 22/24 across Linux/macOS/Windows); bumped the lint job Node 20 → 22
- Docs aligned: README, CONTRIBUTING, CLAUDE.md, DECISIONS.md, CHANGELOG

No application code changed. Full test suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)