### PR TITLE
chore: ignore unadoptable dependency majors in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,19 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: development
+    ignore:
+      # typescript-eslint (even the latest 8.x) caps its peer range at
+      # `typescript <6.1.0` and hard-crashes when driven by TypeScript 6/7
+      # (tsgo): eslint dies with "Cannot read properties of undefined
+      # (reading 'Cjs')". The repo cannot adopt a TS major until
+      # typescript-eslint supports it, so hold typescript at 5.x here.
+      - dependency-name: typescript
+        update-types: [version-update:semver-major]
+      # @types/node is deliberately pinned to the 22.x line to match
+      # `engines.node >=22` (the published CLI's minimum supported Node).
+      # Major bumps would model APIs newer than the supported runtime.
+      - dependency-name: '@types/node'
+        update-types: [version-update:semver-major]
 
   # Dependencies for the Astro landing site (web/). The leaderboard server
   # itself has ZERO npm dependencies (bun:sqlite + Bun builtins only), so it has
@@ -32,3 +45,11 @@ updates:
       interval: weekly
     commit-message:
       prefix: deps
+    ignore:
+      # `astro check` runs @astrojs/check / @astrojs/language-server, which
+      # crashes under TypeScript 6/7 ("Cannot read properties of undefined
+      # (reading 'fileExists')" in getTsconfig). Hold web's typescript at 5.x
+      # until the Astro language tooling supports the new tsgo compiler.
+      # (Astro majors themselves are fine — astro 7 is adopted.)
+      - dependency-name: typescript
+        update-types: [version-update:semver-major]


### PR DESCRIPTION
## What

Adds `ignore` rules to `.github/dependabot.yml` for three dependency majors that cannot currently be adopted, so Dependabot stops re-opening PRs that can never pass CI. Each rule has an inline comment explaining why.

| Ecosystem | Dependency | Ignored | Reason (reproduced locally) |
| --- | --- | --- | --- |
| npm `/` (root dev-deps) | `typescript` | major | typescript-eslint 8.x peers `typescript <6.1.0`; eslint hard-crashes under tsgo. `bun add -d typescript@7 && bun run lint` → `TypeError: Cannot read properties of undefined (reading 'Cjs')`. |
| npm `/` (root dev-deps) | `@types/node` | major | Pinned to 22.x to match `engines.node >=22` (published CLI's minimum Node). |
| npm `/web` | `typescript` | major | `astro check` (@astrojs/language-server) crashes under TS 7 → `Cannot read properties of undefined (reading 'fileExists')`. Astro majors are **not** ignored (astro 7 is adopted in #21). |

## Impact on the open Dependabot PRs

- **#20** (root: `typescript` 5→7 + `@types/node` 22→26) — both parts unadoptable per the rules above. Being closed; once these ignores land, Dependabot will not re-open it.
- **#21** (web: `astro` 5→7) — adoptable and fixed separately (lockfile committed). Astro majors are intentionally left un-ignored.
- **#22** (web: `typescript` 5→7) — unadoptable; being closed and covered by the `/web` typescript ignore.

Verified: `python3 -c "import yaml; yaml.safe_load(...)"` parses the file cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)