### PR TITLE
Fix leaderboard 500: make /data volume writable by non-root server (#26)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -108,16 +108,29 @@ Yesterday's data is discarded — this is intentional, not an archive.
 **Context.** A zero-dependency server needs no build step and no `npm install`,
 so the image can be tiny.
 
-**Decision.** `server/Dockerfile` is `FROM node:24-alpine`, sets
-`NODE_ENV=production`, copies only `package.json index.js db.js` and `public/`,
-runs as the non-root `USER node`, and starts with `node index.js` — no
-`npm install`, no build stage. `server/railway.json` sets `numReplicas: 1` and
+**Decision.** `server/Dockerfile` is a multi-stage build `FROM
+oven/bun:1-alpine`, sets `NODE_ENV=production`, copies only
+`package.json index.ts db.ts` and the built `web/dist` (→ `/app/public`), and
+starts with `bun index.ts` — no `npm install` for the server. The server process
+runs as the non-root `bun` user. A small `docker-entrypoint.sh` runs first as
+root to `chown` the mounted `/data` volume, then drops to `bun` via `su-exec`
+before exec'ing the server. `railway.json` sets `numReplicas: 1` and
 `sleepApplication: true` (scale-to-zero when idle).
 
 **Rationale.** No dependencies means no install layer; Alpine + a single process
 keeps the image small and fast to boot (which matters for scale-to-zero cold
-starts). Running as non-root is basic container hygiene. Sleeping when idle keeps
-a hobby service near free.
+starts). Running the server as non-root is basic container hygiene. Sleeping when
+idle keeps a hobby service near free.
+
+The root-then-drop entrypoint fixes a real outage (issue #26): a build-time
+`chown bun:bun /data` is **shadowed** when Railway mounts the persistent volume
+at `/data` root-owned, so the non-root server could not write the SQLite file —
+every `POST /api/report` crashed with `SQLITE_READONLY` ("attempt to write a
+readonly database") and returned 500. Taking ownership at boot (as root) and
+then dropping privileges keeps the server unprivileged while guaranteeing the
+volume is writable regardless of how the host mounts it. `su-exec` is a ~10 KB
+Alpine package (no npm dependency added, so the zero-npm-dependency invariant
+holds).
 
 **Tradeoffs / accepted risks.** Scale-to-zero adds cold-start latency to the
 first request after idle; acceptable for a leaderboard that clients poll at most

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -19,13 +19,17 @@ FROM oven/bun:1-alpine AS runtime
 ENV NODE_ENV=production
 ENV STATIC_DIR=/app/public
 WORKDIR /app
+# su-exec lets the root entrypoint drop to the `bun` user after fixing volume
+# ownership (Alpine main repo, ~10 KB, no npm dependency added).
+RUN apk add --no-cache su-exec
 COPY server/package.json ./
 COPY server/index.ts server/db.ts ./
+COPY server/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --from=web-build /build/web/dist /app/public
-# Pre-create the volume mount point owned by the runtime user: a fresh volume
-# mounted at /data inherits this ownership, so the non-root server can create
-# LEADERBOARD_DB=/data/leaderboard.db on first boot (an existing volume with
-# data keeps whatever ownership it already has).
-RUN mkdir -p /data && chown bun:bun /data
-USER bun
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh && mkdir -p /data
+# NOTE: the container starts as root ONLY to run the entrypoint, which chowns
+# the mounted /data volume (Railway mounts it root-owned, shadowing any
+# build-time chown) and then execs the server as the non-root `bun` user via
+# su-exec. The server process itself never runs as root — see docs/DECISIONS.md.
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["bun", "index.ts"]

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Docker entrypoint for the Make It Rain leaderboard server.
+#
+# Why this exists: Railway (and most managed hosts) mount the persistent volume
+# at /data owned by root, which SHADOWS the image's build-time `chown bun:bun
+# /data`. The non-root `bun` server process then cannot write the SQLite file,
+# so the very first INSERT in POST /api/report fails with SQLITE_READONLY
+# ("attempt to write a readonly database") and the endpoint returns 500.
+#
+# Fix: start as root, take ownership of the volume (the DB dir + any existing
+# db/-wal/-shm files), then drop privileges to `bun` to run the server. The
+# server itself still runs unprivileged — see docs/DECISIONS.md §1.4.
+set -e
+
+DB_PATH="${LEADERBOARD_DB:-/data/leaderboard.db}"
+DATA_DIR="$(dirname "$DB_PATH")"
+
+# Best-effort: never let an ownership hiccup crash boot. If chown fails (e.g.
+# already correct, or an unusual read-only mount), the server surfaces the real
+# error on first write.
+if [ -d "$DATA_DIR" ]; then
+  chown -R bun:bun "$DATA_DIR" 2>/dev/null || true
+fi
+
+# Drop to the unprivileged user and exec the server (CMD is passed as "$@").
+exec su-exec bun "$@"

--- a/src/lib/leaderboard-client.ts
+++ b/src/lib/leaderboard-client.ts
@@ -400,9 +400,28 @@ export class LeaderboardClient {
         body: JSON.stringify({ tag: this.config.gamerTag, total }),
         signal: controller ? controller.signal : undefined,
       });
-      return !!(res && res.ok);
-    } catch {
-      return false; // unreachable / DNS / abort / anything — stay silent
+      const ok = !!(res && res.ok);
+      // Hardening (issue #26): a server-side outage used to be completely
+      // invisible because a non-2xx just returned false. Log the status so a
+      // broken /api/report is diagnosable, without changing the fail-silent,
+      // no-retry, never-crash contract (the return value is unchanged and the
+      // next tick is still the only retry).
+      if (!ok) {
+        console.warn(
+          `[make-it-rain] leaderboard report rejected (HTTP ${
+            res && typeof res.status === 'number' ? res.status : '?'
+          })`
+        );
+      }
+      return ok;
+    } catch (err) {
+      // unreachable / DNS / abort / anything — never throw, never retry.
+      console.warn(
+        `[make-it-rain] leaderboard report failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      return false;
     } finally {
       if (timeout) clearTimeout(timeout);
       this._reporting = false;


### PR DESCRIPTION
Fixes #26.

## Root cause

The Railway log (screenshot in the issue) shows the real failure, which is **not** the validation/DB-logic bug the issue text hypothesized:

```
SQLiteError: attempt to write a readonly database   (code: SQLITE_READONLY)
    at report (/app/db.ts:82:21)   ← this.reportStmt.run(day, tag, total)
```

The handler and SQL are correct. The non-root `bun` server can't write the SQLite file: the `Dockerfile` did a **build-time** `chown bun:bun /data`, but Railway mounts the persistent volume at `/data` **root-owned at runtime**, shadowing that chown. The DB then opens read-only, so the first `INSERT` on any valid `POST /api/report` throws `SQLITE_READONLY` → 500. Reads (`GET`) kept working, matching the "site up, reports crash" symptom.

## Changes

**Backend (the actual outage):**
- `server/docker-entrypoint.sh` (new): starts as root, `chown -R bun:bun` the `/data` volume, then drops to the unprivileged `bun` user via `su-exec` before exec'ing the server. The server process still runs non-root (DECISIONS §1.4).
- `server/Dockerfile`: `apk add --no-cache su-exec` (~10 KB, Alpine main repo — no npm dep, zero-dependency invariant holds), install entrypoint, drop `USER bun`, wire `ENTRYPOINT`.
- `docs/DECISIONS.md` §1.4: was still describing the pre-Bun `node:24-alpine` / `USER node` container — updated to Bun + the root-then-drop entrypoint with the issue #26 rationale.

**Client (requested hardening):**
- `src/lib/leaderboard-client.ts`: `reportNow()` now `console.warn`s the HTTP status on a non-2xx and the error on a throw, so an outage is no longer invisible. Contract unchanged — still returns `false`, never throws, never retries early.

## Verification

- `bunx tsc --noEmit` clean
- `bun run test` — **57/57 pass** (new warnings visible in output for the 500 / ECONNREFUSED cases)
- `bun run lint` + `bun run format:check` clean
- `sh -n server/docker-entrypoint.sh` valid

Docker build itself not run locally; the definitive confirmation is a Railway redeploy, after which `curl -X POST https://aiburn.dev/api/report -d '{"tag":"DiagProbe1","total":1.23}'` should return `200 {"ok":true,...}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)