### PR TITLE
Harden leaderboard server + report every 10 min

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -113,7 +113,10 @@ oven/bun:1-alpine`, sets `NODE_ENV=production`, copies only
 `package.json index.ts db.ts` and the built `web/dist` (→ `/app/public`), and
 starts with `bun index.ts` — no `npm install` for the server. The server process
 runs as the non-root `bun` user. A small `docker-entrypoint.sh` runs first as
-root to `chown` the mounted `/data` volume, then drops to `bun` via `su-exec`
+root to `chown` the mounted `/data` volume — non-recursively and only the
+directory plus the exact SQLite paths (with `chown -h`, so a symlink planted in
+the volume by a hypothetically compromised server can never redirect a
+root-privileged chown at another file) — then drops to `bun` via `su-exec`
 before exec'ing the server. `railway.json` sets `numReplicas: 1` and
 `sleepApplication: true` (scale-to-zero when idle).
 
@@ -341,8 +344,10 @@ status (the label was previously wrong).
 `server/index.js`): default `RATE_LIMIT_MAX` = 60 requests per
 `RATE_LIMIT_WINDOW_MS` = 60,000 ms (60/min/IP), both env-overridable. Exceeding
 it returns `429 rate_limited` with a `Retry-After` header. The client IP is the
-**leftmost** entry of `x-forwarded-for` (Railway sits behind a proxy, so
-`req.socket.remoteAddress` is the proxy), falling back to the socket address. A
+**rightmost** entry of `x-forwarded-for` — the one appended by the trusted
+proxy directly in front of us (Railway), which a client cannot spoof; the
+leftmost entries are client-supplied and would let an attacker bypass the
+limiter with a random fake IP per request. Falls back to the socket address. A
 low-frequency background sweeper drops expired buckets so the map stays
 memory-bounded; the sweeper is `.unref()`'d so it never keeps the process alive
 (tests/CLI exit cleanly).
@@ -350,9 +355,10 @@ memory-bounded; the sweeper is `.unref()`'d so it never keeps the process alive
 **Rationale.** Legit clients report at most hourly, so 60/min/IP never
 inconveniences a real user while stopping a trivial single-source flood.
 
-**Tradeoffs / accepted risks.** `x-forwarded-for` is client-influenceable, so
-this is explicitly **best-effort** — it stops a naive single-origin flood, **not**
-a distributed/spoofed one. Consciously accepted.
+**Tradeoffs / accepted risks.** Trusting the rightmost `x-forwarded-for` entry
+assumes exactly one proxy hop in front of the server (true on Railway). This
+stops single-origin floods including spoofed-XFF ones, but **not** a genuinely
+distributed flood. Consciously accepted.
 
 **Status.** Shipped.
 

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -18,9 +18,19 @@ DATA_DIR="$(dirname "$DB_PATH")"
 # Best-effort: never let an ownership hiccup crash boot. If chown fails (e.g.
 # already correct, or an unusual read-only mount), the server surfaces the real
 # error on first write.
+#
+# Deliberately NOT `chown -R`: this runs as root over a directory the
+# unprivileged server writes to, so we only touch the directory itself plus the
+# exact SQLite paths we own, and use -h so a symlink planted in the volume can
+# never redirect the chown at a root-owned file elsewhere in the container.
 if [ -d "$DATA_DIR" ]; then
-  chown -R bun:bun "$DATA_DIR" 2>/dev/null || true
+  chown bun:bun "$DATA_DIR" 2>/dev/null || true
 fi
+for f in "$DB_PATH" "$DB_PATH-wal" "$DB_PATH-shm"; do
+  if [ -e "$f" ] || [ -L "$f" ]; then
+    chown -h bun:bun "$f" 2>/dev/null || true
+  fi
+done
 
 # Drop to the unprivileged user and exec the server (CMD is passed as "$@").
 exec su-exec bun "$@"

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,7 +18,7 @@
  */
 
 import { existsSync } from 'node:fs';
-import { extname, join, normalize } from 'node:path';
+import { extname, join, normalize, sep } from 'node:path';
 import { LeaderboardDB } from './db.ts';
 
 // Minimal structural view of the Bun `Server` passed to a fetch handler: we only
@@ -102,13 +102,18 @@ function jsonResponse(
   return new Response(JSON.stringify(obj), { status, headers });
 }
 
-// Best-effort client IP: prefer the FIRST (leftmost) x-forwarded-for entry set
-// by the proxy in front of us; fall back to the raw socket when the header is
-// absent (e.g. local/direct connections). XFF is spoofable, so treat as a hint.
+// Best-effort client IP: prefer the LAST (rightmost) x-forwarded-for entry —
+// that is the one appended by the trusted proxy directly in front of us
+// (Railway), so a client cannot spoof it by sending its own XFF header. The
+// leftmost entries are client-supplied and would let an attacker bypass the
+// rate limiter (and bloat the bucket map) with a random fake IP per request.
+// Assumes exactly one trusted proxy hop; falls back to the raw socket when the
+// header is absent (e.g. local/direct connections).
 function clientIp(req: Request, server: RequestIpServer): string {
   const xff = req.headers.get('x-forwarded-for');
   if (xff && xff.length > 0) {
-    return xff.split(',')[0]!.trim();
+    const parts = xff.split(',');
+    return parts[parts.length - 1]!.trim();
   }
   return server.requestIP(req)?.address || '';
 }
@@ -131,7 +136,12 @@ async function serveStatic(
 ): Promise<Response> {
   const rel = pathname === '/' ? 'index.html' : pathname.replace(/^\/+/, '');
   const filePath = normalize(join(staticDir, rel));
-  if (!filePath.startsWith(staticDir)) {
+  // Containment check: compare against the directory WITH a trailing separator
+  // so a sibling sharing the prefix (e.g. /app/public-evil next to /app/public)
+  // can never pass. The URL parser already normalizes ../ segments out of
+  // pathname; this is defense-in-depth.
+  const base = staticDir.endsWith(sep) ? staticDir : staticDir + sep;
+  if (!filePath.startsWith(base)) {
     return new Response('Forbidden', { status: 403 });
   }
   const file = Bun.file(filePath);
@@ -169,9 +179,9 @@ export function createApp(config: AppConfig = {}): App {
   const maxTotal =
     config.maxTotal ?? (Number(process.env.MAX_REPORT_TOTAL) || 10000);
 
-  // Per-IP rate limiting for POST /api/report. Legit clients report at most
-  // hourly, so a generous ceiling (60 req/min/IP by default) never inconveniences
-  // real users while stopping a trivial single-source flood.
+  // Per-IP rate limiting for POST /api/report. Legit clients report every 10
+  // minutes (~6/hr), so a generous ceiling (60 req/min/IP by default) never
+  // inconveniences real users while stopping a trivial single-source flood.
   const rateLimitMax =
     config.rateLimitMax ?? (Number(process.env.RATE_LIMIT_MAX) || 60);
   const rateLimitWindowMs =

--- a/src/lib/leaderboard-client.ts
+++ b/src/lib/leaderboard-client.ts
@@ -29,7 +29,7 @@ const LEGACY_PLACEHOLDER_URLS = [
   'https://make-it-rain.example.com',
   'https://claude-make-it-rain-production.up.railway.app',
 ];
-const DEFAULT_REPORT_INTERVAL_MS = 60 * 60 * 1000; // hourly
+const DEFAULT_REPORT_INTERVAL_MS = 10 * 60 * 1000; // every 10 minutes
 const REQUEST_TIMEOUT_MS = 8000;
 const CONFIG_FILENAME = 'config.json';
 const TAG_MAX_LENGTH = 32;

--- a/src/main.ts
+++ b/src/main.ts
@@ -620,7 +620,7 @@ if (!app.requestSingleInstanceLock()) {
       handleUpdate(previousTotal, snapshot);
     monitor.start();
 
-    // Cloud daily leaderboard: anonymized tag + today's total, reported hourly.
+    // Cloud daily leaderboard: anonymized tag + today's total, reported every 10 min.
     // Telemetry is ON by default but disclosed and toggleable from the tray menu.
     // MIR_API_BASE_URL=http://localhost:8787 points reports and the "View
     // leaderboard" page at a local server for this process only — it is never

--- a/test/leaderboard-server.test.ts
+++ b/test/leaderboard-server.test.ts
@@ -229,6 +229,30 @@ test('per-IP rate limiter (429 + Retry-After past limit, other IP OK)', async ()
   expect(other.status).toBe(200);
 });
 
+test('rate limiter keys on the proxy-appended (rightmost) XFF entry', async () => {
+  // A client can prepend arbitrary entries to x-forwarded-for; only the
+  // RIGHTMOST one is appended by the trusted proxy in front of the server. If
+  // the limiter keyed on the leftmost entry, each request below would land in
+  // its own bucket and the flood would never trip 429.
+  for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+    const ok = await request(
+      'POST',
+      '/api/report',
+      { tag: 'Spoof', total: 1 },
+      { 'x-forwarded-for': `10.0.${i}.1, 192.0.2.50` }
+    );
+    expect(ok.status).toBe(200);
+  }
+  const blocked = await request(
+    'POST',
+    '/api/report',
+    { tag: 'Spoof', total: 1 },
+    { 'x-forwarded-for': '10.99.99.99, 192.0.2.50' }
+  );
+  expect(blocked.status).toBe(429);
+  expect(JSON.parse(blocked.body).error).toBe('rate_limited');
+});
+
 test('security headers (nosniff + JSON type + CSP on HTML)', async () => {
   const board = await request('GET', '/api/leaderboard');
   expect(

--- a/web/src/components/Hero.astro
+++ b/web/src/components/Hero.astro
@@ -26,7 +26,8 @@
     <div class="amt" id="tallyAmt">$0.00</div>
     <p class="cap">
       made it rain today across <b id="tallyCount">0</b>
-      <span id="tallyNoun">spenders</span>
+      <span id="tallyNoun"> spenders</span> — each total updates every 10&nbsp;min
+      while their app is running
     </p>
   </div>
 </header>


### PR DESCRIPTION
## Summary

Bundles two changes to the leaderboard.

### 1. Server security hardening
- **Rate limiter anti-spoof**: keys on the **rightmost** (proxy-appended) `x-forwarded-for` entry instead of the client-supplied leftmost one, so a client can't bypass the limiter (or bloat the bucket map) with a random fake IP per request. Assumes exactly one trusted proxy hop — true on Railway.
- **Static-serve containment**: compares the resolved path against the static dir *with a trailing separator*, so a sibling sharing the prefix (`/app/public-evil` vs `/app/public`) can't pass. Defense-in-depth on top of URL `../` normalization.
- **`docker-entrypoint.sh`**: drops the recursive `chown -R` of `/data`. Only the directory and the exact SQLite paths (`.db`, `-wal`, `-shm`) are chowned, using `chown -h` so a symlink planted in the volume can't redirect a root-privileged chown at another file.
- Docs (`DECISIONS.md`) updated + a new test asserting rightmost-XFF keying.

### 2. Faster reporting
- Client report interval **1h → 10 min** (`DEFAULT_REPORT_INTERVAL_MS`).
- Clearer web tally copy: *"each total updates every 10 min while their app is running"* (was the vague "data pulled every 1h or on restart").

**No flooding risk from the shorter interval:** the server upserts one row per `(day, tag)` keeping `MAX(total)` (no DB growth), and 6 req/hr per app is far under the 60 req/min/IP rate limit.

## Test plan
- [x] `bun run test` — 58/58 pass (incl. new rightmost-XFF test)
- [x] `bunx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)