### PR TITLE
Widen hero install commands to match graph panel width

### DIFF
--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -379,7 +379,6 @@ header.hero { text-align: center; margin-bottom: clamp(28px, 5vh, 44px); }
   display: flex;
   flex-direction: column;
   gap: 8px;
-  max-width: 460px;
 }
 .install .cmd {
   display: flex;


### PR DESCRIPTION
The .install max-width:460px capped the npm/CLI command rows well short of the 660px .wrap container, leaving them visibly narrower than the collective-spend graph and rest of the page content below.

<!-- Thanks for contributing! Keep this short — delete sections that don't apply. -->

## What & why

<!-- What does this change do, and what problem does it solve? -->

## How I tested

<!-- e.g. `bun run test`, ran the app on macOS, hit the leaderboard endpoint. -->

## Checklist

- [ ] `bun run test` passes
- [ ] `bun run lint` passes
- [ ] Docs/README updated if behavior changed
- [ ] No secrets, tokens, or personal data committed
