### PR TITLE
feat: rotate featured equivalence items daily + fix menu copy

### DIFF
--- a/src/lib/equivalences.ts
+++ b/src/lib/equivalences.ts
@@ -103,12 +103,41 @@ function clampUSD(totalUSD?: number | null): number {
 }
 
 /**
+ * Days since the Unix epoch in the caller's LOCAL timezone. Passed as the
+ * `dayIndex` seed to the matchers below so the featured item rotates once per
+ * calendar day (a burger today, a pizza tomorrow) instead of always landing on
+ * the same "best fit". Defaults to the current local day.
+ */
+export function localDayIndex(now: Date = new Date()): number {
+  return Math.floor(
+    (now.getTime() - now.getTimezoneOffset() * 60000) / 86400000
+  );
+}
+
+/** Pick from a non-empty pool: rotate by `dayIndex` when given, else index 0. */
+function rotate<T>(pool: T[], dayIndex?: number | null): T {
+  if (typeof dayIndex === 'number' && isFinite(dayIndex) && pool.length > 1) {
+    return pool[
+      ((Math.trunc(dayIndex) % pool.length) + pool.length) % pool.length
+    ]!;
+  }
+  return pool[0]!;
+}
+
+/**
  * Match an individual total to the treat that yields the most natural small
  * count (nearest to ~3, tie-broken toward the pricier item so counts stay low).
  * Returns null for a zero/invalid total so callers can show their own "nothing
  * yet" copy.
+ *
+ * Pass `dayIndex` (see {@link localDayIndex}) to rotate the featured item once
+ * per day across everything the total can afford, instead of always showing the
+ * same best-fit item. Omit it to keep the deterministic best-fit behavior.
  */
-export function treats(totalUSD?: number | null): TreatMatch | null {
+export function treats(
+  totalUSD?: number | null,
+  dayIndex?: number | null
+): TreatMatch | null {
   const usd = clampUSD(totalUSD);
   if (usd <= 0) return null;
 
@@ -118,21 +147,27 @@ export function treats(totalUSD?: number | null): TreatMatch | null {
   const affordable = SMALL_TREATS.filter((t) => usd >= t.unitUSD);
   const pool = affordable.length > 0 ? affordable : [SMALL_TREATS[0]!];
 
-  let best = pool[0]!;
-  let bestCount = Math.max(1, Math.round(usd / best.unitUSD));
-  let bestScore = Infinity;
-  for (const t of pool) {
-    const count = Math.max(1, Math.round(usd / t.unitUSD));
-    const score = Math.abs(count - TREAT_TARGET_COUNT);
-    if (
-      score < bestScore ||
-      (score === bestScore && t.unitUSD > best.unitUSD)
-    ) {
-      best = t;
-      bestCount = count;
-      bestScore = score;
+  let best: Treat;
+  if (typeof dayIndex === 'number' && isFinite(dayIndex)) {
+    // Rotate through the affordable items so the pick changes each day.
+    best = rotate(pool, dayIndex);
+  } else {
+    // Deterministic: the item whose count lands nearest the natural target.
+    best = pool[0]!;
+    let bestScore = Infinity;
+    for (const t of pool) {
+      const count = Math.max(1, Math.round(usd / t.unitUSD));
+      const score = Math.abs(count - TREAT_TARGET_COUNT);
+      if (
+        score < bestScore ||
+        (score === bestScore && t.unitUSD > best.unitUSD)
+      ) {
+        best = t;
+        bestScore = score;
+      }
     }
   }
+  const bestCount = Math.max(1, Math.round(usd / best.unitUSD));
   const label = bestCount === 1 ? best.singular : best.plural;
   return {
     count: bestCount,
@@ -155,16 +190,24 @@ function pct(ratio: number): string {
  * "≈ 10% of a trip to Greece". Picks the smallest big-ticket the total does NOT
  * exceed (so the percentage is meaningful and < 100%); if the total dwarfs every
  * item, expresses it as a multiple of the largest ("3× the Titanic").
+ *
+ * Pass `dayIndex` (see {@link localDayIndex}) to rotate the reference item once
+ * per day across every big-ticket the total hasn't exceeded, so the framing
+ * stays fresh. Omit it to keep the deterministic smallest-fit behavior.
  */
 export function bigTicketFraction(
-  totalUSD?: number | null
+  totalUSD?: number | null,
+  dayIndex?: number | null
 ): BigTicketMatch | null {
   const usd = clampUSD(totalUSD);
   if (usd <= 0) return null;
 
+  // Candidates the total reads as a fraction of (< 100%), smallest-first.
+  const fractional = BIG_TICKETS.filter((b) => b.unitUSD > usd);
   const reference =
-    BIG_TICKETS.find((b) => b.unitUSD > usd) ??
-    BIG_TICKETS[BIG_TICKETS.length - 1]!;
+    fractional.length > 0
+      ? rotate(fractional, dayIndex)
+      : BIG_TICKETS[BIG_TICKETS.length - 1]!;
   const name = `${reference.article} ${reference.label}`;
   if (usd >= reference.unitUSD) {
     const times = Math.round((usd / reference.unitUSD) * 10) / 10;
@@ -181,18 +224,22 @@ export function bigTicketFraction(
  * community headline: "≈ a trip to Greece" or "≈ 3× a trip to Greece". Picks the
  * largest big-ticket the total reaches; falls back to a fractional framing when
  * the total is below even the smallest item.
+ *
+ * Pass `dayIndex` (see {@link localDayIndex}) to rotate the headline item once
+ * per day across every big-ticket the total has reached (each is still true —
+ * the total does add up to that many of it). Omit it to keep naming the largest.
  */
 export function bigTicketReached(
-  totalUSD?: number | null
+  totalUSD?: number | null,
+  dayIndex?: number | null
 ): BigTicketMatch | null {
   const usd = clampUSD(totalUSD);
   if (usd <= 0) return null;
 
-  let reached: BigTicket | null = null;
-  for (const b of BIG_TICKETS) {
-    if (usd >= b.unitUSD) reached = b;
-  }
-  if (!reached) return bigTicketFraction(usd);
+  // Every item the total reaches, largest-first so index 0 is the default pick.
+  const reachedPool = BIG_TICKETS.filter((b) => usd >= b.unitUSD).reverse();
+  if (reachedPool.length === 0) return bigTicketFraction(usd, dayIndex);
+  const reached = rotate(reachedPool, dayIndex);
 
   const name = `${reached.article} ${reached.label}`;
   const times = usd / reached.unitUSD;

--- a/src/main.ts
+++ b/src/main.ts
@@ -165,8 +165,10 @@ function wealthSubmenu(totalUSD: number): MenuItemConstructorOptions[] {
     { type: 'separator' },
     { label: '💰 = $100   💵 = $1   🪙 = 1¢', enabled: false },
   ];
-  const treat = equivalences.treats(totalUSD);
-  const slice = equivalences.bigTicketFraction(totalUSD);
+  // Rotate the featured items once per day so the reflection stays fresh.
+  const day = equivalences.localDayIndex();
+  const treat = equivalences.treats(totalUSD, day);
+  const slice = equivalences.bigTicketFraction(totalUSD, day);
   if (treat || slice) {
     items.push({ type: 'separator' });
     if (treat) {
@@ -208,7 +210,7 @@ function rebuildTrayMenu(): void {
     },
     { type: 'separator' },
     {
-      label: 'See your wealth',
+      label: 'See your numbers',
       submenu: wealthSubmenu(s.totalCostUSD),
     },
     { label: 'Past spending', submenu: RANGES.map(historyMenuItem) }
@@ -218,9 +220,9 @@ function rebuildTrayMenu(): void {
     const lb = leaderboard;
     template.push(
       { type: 'separator' },
-      { label: `Leaderboard tag: ${lb.gamerTag}`, enabled: false },
+      { label: `User tag: ${lb.gamerTag}`, enabled: false },
       {
-        label: 'Share on daily leaderboard',
+        label: 'Share on collective spend',
         type: 'checkbox',
         checked: lb.telemetryEnabled,
         click: (item: MenuItem) => {
@@ -236,7 +238,7 @@ function rebuildTrayMenu(): void {
           rebuildTrayMenu();
         },
       },
-      { label: 'View leaderboard…', click: () => openLeaderboardPage() }
+      { label: "View everyone's spend…", click: () => openLeaderboardPage() }
     );
   }
 

--- a/test/equivalences.test.ts
+++ b/test/equivalences.test.ts
@@ -6,6 +6,7 @@ import {
   treats,
   bigTicketFraction,
   bigTicketReached,
+  localDayIndex,
   SMALL_TREATS,
   BIG_TICKETS,
 } from '../src/lib/equivalences';
@@ -86,4 +87,49 @@ test('bigTicketReached falls back to a fraction below the smallest big item', ()
   const r = bigTicketReached(50); // below the cheapest big-ticket
   assert.ok(r);
   assert.ok(/%\sof\s/.test(r!.text));
+});
+
+// ── Daily rotation: passing a dayIndex cycles the featured item ──────────────
+test('localDayIndex is a stable whole number for a fixed date', () => {
+  const d = new Date('2026-07-14T09:00:00Z');
+  assert.strictEqual(localDayIndex(d), Math.floor(localDayIndex(d)));
+  assert.strictEqual(localDayIndex(d), localDayIndex(d)); // deterministic
+});
+
+test('treats rotates the featured item across days and stays consistent per day', () => {
+  // $200 can afford several treats, so rotation has room to move.
+  const seen = new Set<string>();
+  for (let day = 0; day < SMALL_TREATS.length * 2; day++) {
+    const t = treats(200, day);
+    assert.ok(t);
+    seen.add(t!.label);
+    assert.strictEqual(treats(200, day)!.label, t!.label); // same day → same item
+  }
+  assert.ok(seen.size > 1, 'expected more than one distinct item across days');
+});
+
+test('treats without a dayIndex keeps deterministic best-fit behavior', () => {
+  assert.strictEqual(treats(24)!.text, treats(24)!.text);
+  assert.strictEqual(treats(24, undefined)!.text, treats(24)!.text);
+});
+
+test('bigTicketFraction rotates the reference across days', () => {
+  const seen = new Set<string>();
+  for (let day = 0; day < BIG_TICKETS.length * 2; day++) {
+    const f = bigTicketFraction(10, day); // below every big-ticket → all candidates
+    assert.ok(f);
+    seen.add(f!.text);
+  }
+  assert.ok(seen.size > 1);
+});
+
+test('bigTicketReached rotates among reached items, each still truthful', () => {
+  const total = BIG_TICKETS[2]!.unitUSD + 10; // reaches the first three items
+  const seen = new Set<string>();
+  for (let day = 0; day < 6; day++) {
+    const r = bigTicketReached(total, day);
+    assert.ok(r);
+    seen.add(r!.text);
+  }
+  assert.ok(seen.size > 1);
 });

--- a/web/src/lib/equivalences.ts
+++ b/web/src/lib/equivalences.ts
@@ -76,28 +76,52 @@ function clampUSD(totalUSD?: number | null): number {
     : 0;
 }
 
-export function treats(totalUSD?: number | null): TreatMatch | null {
+/** Days since the Unix epoch in the caller's LOCAL timezone (rotation seed). */
+export function localDayIndex(now: Date = new Date()): number {
+  return Math.floor(
+    (now.getTime() - now.getTimezoneOffset() * 60000) / 86400000
+  );
+}
+
+/** Pick from a non-empty pool: rotate by `dayIndex` when given, else index 0. */
+function rotate<T>(pool: T[], dayIndex?: number | null): T {
+  if (typeof dayIndex === 'number' && isFinite(dayIndex) && pool.length > 1) {
+    return pool[
+      ((Math.trunc(dayIndex) % pool.length) + pool.length) % pool.length
+    ]!;
+  }
+  return pool[0]!;
+}
+
+export function treats(
+  totalUSD?: number | null,
+  dayIndex?: number | null
+): TreatMatch | null {
   const usd = clampUSD(totalUSD);
   if (usd <= 0) return null;
 
   const affordable = SMALL_TREATS.filter((t) => usd >= t.unitUSD);
   const pool = affordable.length > 0 ? affordable : [SMALL_TREATS[0]!];
 
-  let best = pool[0]!;
-  let bestCount = Math.max(1, Math.round(usd / best.unitUSD));
-  let bestScore = Infinity;
-  for (const t of pool) {
-    const count = Math.max(1, Math.round(usd / t.unitUSD));
-    const score = Math.abs(count - TREAT_TARGET_COUNT);
-    if (
-      score < bestScore ||
-      (score === bestScore && t.unitUSD > best.unitUSD)
-    ) {
-      best = t;
-      bestCount = count;
-      bestScore = score;
+  let best: Treat;
+  if (typeof dayIndex === 'number' && isFinite(dayIndex)) {
+    best = rotate(pool, dayIndex);
+  } else {
+    best = pool[0]!;
+    let bestScore = Infinity;
+    for (const t of pool) {
+      const count = Math.max(1, Math.round(usd / t.unitUSD));
+      const score = Math.abs(count - TREAT_TARGET_COUNT);
+      if (
+        score < bestScore ||
+        (score === bestScore && t.unitUSD > best.unitUSD)
+      ) {
+        best = t;
+        bestScore = score;
+      }
     }
   }
+  const bestCount = Math.max(1, Math.round(usd / best.unitUSD));
   const label = bestCount === 1 ? best.singular : best.plural;
   return {
     count: bestCount,
@@ -115,14 +139,17 @@ function pct(ratio: number): string {
 }
 
 export function bigTicketFraction(
-  totalUSD?: number | null
+  totalUSD?: number | null,
+  dayIndex?: number | null
 ): BigTicketMatch | null {
   const usd = clampUSD(totalUSD);
   if (usd <= 0) return null;
 
+  const fractional = BIG_TICKETS.filter((b) => b.unitUSD > usd);
   const reference =
-    BIG_TICKETS.find((b) => b.unitUSD > usd) ??
-    BIG_TICKETS[BIG_TICKETS.length - 1]!;
+    fractional.length > 0
+      ? rotate(fractional, dayIndex)
+      : BIG_TICKETS[BIG_TICKETS.length - 1]!;
   const name = `${reference.article} ${reference.label}`;
   if (usd >= reference.unitUSD) {
     const times = Math.round((usd / reference.unitUSD) * 10) / 10;
@@ -135,16 +162,15 @@ export function bigTicketFraction(
 }
 
 export function bigTicketReached(
-  totalUSD?: number | null
+  totalUSD?: number | null,
+  dayIndex?: number | null
 ): BigTicketMatch | null {
   const usd = clampUSD(totalUSD);
   if (usd <= 0) return null;
 
-  let reached: BigTicket | null = null;
-  for (const b of BIG_TICKETS) {
-    if (usd >= b.unitUSD) reached = b;
-  }
-  if (!reached) return bigTicketFraction(usd);
+  const reachedPool = BIG_TICKETS.filter((b) => usd >= b.unitUSD).reverse();
+  if (reachedPool.length === 0) return bigTicketFraction(usd, dayIndex);
+  const reached = rotate(reachedPool, dayIndex);
 
   const name = `${reached.article} ${reached.label}`;
   const times = usd / reached.unitUSD;

--- a/web/src/lib/leaderboard.ts
+++ b/web/src/lib/leaderboard.ts
@@ -14,7 +14,12 @@
  * gracefully so a missing or slow backend never breaks the page.
  */
 
-import { treats, bigTicketFraction, bigTicketReached } from './equivalences';
+import {
+  treats,
+  bigTicketFraction,
+  bigTicketReached,
+  localDayIndex,
+} from './equivalences';
 
 // ── API contract (mirrors server) ────────────────────────────────────────────
 export interface LeaderboardEntry {
@@ -234,7 +239,7 @@ function renderCollective(data: CollectiveData): void {
 
   const eqEl = byId('collectiveEq');
   if (eqEl) {
-    const big = bigTicketReached(total);
+    const big = bigTicketReached(total, localDayIndex());
     eqEl.textContent = big ? `Together, that's ≈ ${big.text} ${big.emoji}` : '';
   }
 
@@ -277,8 +282,9 @@ function renderReflection(
     return;
   }
 
-  const treat = treats(yours);
-  const slice = bigTicketFraction(yours);
+  const day = localDayIndex();
+  const treat = treats(yours, day);
+  const slice = bigTicketFraction(yours, day);
   const share =
     collectiveTotal > 0
       ? Math.max(0.1, Math.round((yours / collectiveTotal) * 1000) / 10)


### PR DESCRIPTION
Rotate the featured spend equivalences once per calendar day so the reflection stays fresh, instead of always showing the same best-fit item.

- Add localDayIndex() + an optional dayIndex seed to treats(), bigTicketFraction(), and bigTicketReached(); omitting it preserves the old deterministic behavior (existing tests unchanged).
- Wire the in-app "See your numbers" submenu and the web leaderboard (collective headline + ?tag= reflection) to pass today's index.
- Mirror the changes into web/src/lib/equivalences.ts to keep the tables in sync.
- Fix tray copy grammar: "collective spent" -> "collective spend", "View everyones spent" -> "View everyone's spend".

<!-- Thanks for contributing! Keep this short — delete sections that don't apply. -->

## What & why

<!-- What does this change do, and what problem does it solve? -->

## How I tested

<!-- e.g. `bun run test`, ran the app on macOS, hit the leaderboard endpoint. -->

## Checklist

- [ ] `bun run test` passes
- [ ] `bun run lint` passes
- [ ] Docs/README updated if behavior changed
- [ ] No secrets, tokens, or personal data committed
